### PR TITLE
fix url to cpu

### DIFF
--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -7,7 +7,7 @@ person:
   location: Computational Proteomics Unit, University of Cambridge
   citizenship: UK
   email: lms79@cam.ac.uk
-  site: http://cpu.sysbiol.cam.ac.uk 
+  site: cpu.sysbiol.cam.ac.uk 
   phone: --
   github: /lmsimp
 


### PR DESCRIPTION
The url, although correct in the source and when displayed, got changed when clicked (`:` missing). This seems to fix it, at least when testing locally.